### PR TITLE
Split withMetric and remove functional dependency

### DIFF
--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -27,8 +27,8 @@ main = do
             threadDelay 2000000
           let method = if even x then "GET" else "POST"
               status = Tx.pack (show x) <> "00"
-          Prom.withMetric _msCounter Prom.incCounter
-          Prom.withMetric _msVCounter $ \v ->
+          Prom.withMetricIO _msCounter Prom.incCounter
+          Prom.withMetricIO _msVCounter $ \v ->
             Prom.withLabel v (method Prom.:> status Prom.:> Prom.LNil) Prom.incCounter
           go (if x == 4 then 1 else x + 1)
     go 1

--- a/src/GenericPrometheus.hs
+++ b/src/GenericPrometheus.hs
@@ -4,10 +4,10 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PolyKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
@@ -368,7 +368,7 @@ withMetric get k =
   getMetrics >>= k . coerce . get
 
 -- |The class of 'Monad's with access to a set of @metrics@.
-class Monad m => MonadPrometheus metrics m | m -> metrics where
+class Monad m => MonadPrometheus metrics m where
   getMetrics :: m metrics
 
 -- |An identity 'Monad' transformer that can be used with @deriving via@ to

--- a/src/GenericPrometheus.hs
+++ b/src/GenericPrometheus.hs
@@ -235,6 +235,16 @@ import Text.Read (readMaybe)
 -- Prom.withMetricIO _msVCounter $ \v ->
 --   Prom.withLabel v ("GET" :> "200" :> LNil) Prom.incCounter
 -- @
+--
+-- To keep track of the time taken by some part of your program, you should use
+-- 'observeDuration'. However, the action whose time you want to track might not
+-- be in 'IO'. In this case, 'withMetric' allows you to run the action in the
+-- same monad.
+--
+-- @
+-- Prom.withMetric _msSummary $ \metric -> Prom.observeDuration metric $ do
+--   getStuffFromDB
+-- @
 
 -- $metrics
 --
@@ -353,9 +363,12 @@ withMetricIO get k =
 -- |Inside some 'MonadPrometheus' @m@ with access to a record of metrics with
 --  type @metrics@, accepts a function to select a metric and a function to
 --  modify it and applies the modification appropriately. Contrary to
---  'withMetricIO', it does let you run the modification code in the same monad.
+--  'withMetricIO', it lets you run the modification code in the same monad.
 --
 --  @
+--  Prim.withMetric _msSummary $ \metric -> Prom.observeDuration metric $ do
+--    -- We remain in the same monad here.
+--    doSomething
 --  @
 withMetric
   :: ( MonadPrometheus metrics m


### PR DESCRIPTION
`withMetric` now takes `(metric -> m a)` instead of `metric -> IO a` so that we can use `observeDuration` together with `withMetric` for example. The old behaviour is moved to `withMetricIO`.

I also removed the functional dependency in `MonadPrometheus`. It looks legitimate to have several ones, e.g. the main application has one metrics type and uses a library which is itself tracking some metrics