### PR TITLE
Allow nesting of metrics

### DIFF
--- a/generic-prometheus.cabal
+++ b/generic-prometheus.cabal
@@ -21,3 +21,15 @@ library
     , warp
   default-language: Haskell2010
   ghc-options: -Wall -Werror
+
+executable example
+  hs-source-dirs: examples
+  main-is: Example.hs
+  build-depends:
+    , generic-prometheus
+    , base
+    , async
+    , text
+    , mtl
+    , lens
+    , generic-lens


### PR DESCRIPTION
The idea is to have various libraries and packages defining and using
their own Metric type, and the final binary can group all of these
in its environment with minimal effort.